### PR TITLE
Don't try to edit ENV in ruby...you can't.

### DIFF
--- a/opsworks_custom_env/definitions/custom_env_template.rb
+++ b/opsworks_custom_env/definitions/custom_env_template.rb
@@ -9,7 +9,7 @@ define :custom_env_template do
 
   params[:env].each do |key, value|
     Chef::Log.info("Setting ENV[#{key}] to #{value}")
-    ENV[key] = value
+    # ENV[key] = value
     `export #{key}=#{value}`
   end
 


### PR DESCRIPTION
@mbradshawabs  Mark, this line was causing a failure when running the recipe because Ruby's ENV[] doesn't like being assigned to.

Would you QA this--make sure you can build and deploy using this branch of the cookbooks?
